### PR TITLE
Fix bug where prepared statements got quotations

### DIFF
--- a/src/sql/Inserter.php
+++ b/src/sql/Inserter.php
@@ -56,7 +56,7 @@ class Inserter extends Query
     public function values(...$values): self
     {
         foreach ($values as $value) {
-            if (is_string($value)) {
+            if (is_string($value) && strpos($value, ':') !== 0 && !is_numeric($value)) {
                 $this->values[] = "'${value}'";
             } else {
                 $this->values[] = $value;


### PR DESCRIPTION
The fix for the initial bug added a new bug where prepared statements got quotation marks around it and ended up inserting this into the table. This fix has added additional checks so that this does not happen.